### PR TITLE
RoomViewクラスで、プライマリコンストラクタを使うようにした

### DIFF
--- a/app/src/main/java/com/kyotob/client/view/RoomView.kt
+++ b/app/src/main/java/com/kyotob/client/view/RoomView.kt
@@ -12,9 +12,7 @@ import com.kyotob.client.entities.Room
 
 // 個々のRoomViewの雛形を作るつくるクラス
 // RoomViewAdapterで利用する
-class RoomView: FrameLayout {
-    // FrameLayoutが持っているコンストラクタを実装する
-    constructor(context: Context?) : super(context)
+class RoomView(context: Context): FrameLayout(context) {
 //    無くてもいいんじゃね?
 //    constructor(context: Context?,
 //                attrs: AttributeSet?) : super(context, attrs)


### PR DESCRIPTION
セカンダリコンストラクタを用いる必要はないと思います

あと、その引数の ``context`` の型は ``Context?`` ではなく ``Context`` で大丈夫だと思います